### PR TITLE
Update ssh-agent package

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -143,10 +143,10 @@
 			"revisionTime": "2017-07-26T18:22:33Z"
 		},
 		{
-			"checksumSHA1": "iHiMTBffQvWYlOLu3130JXuQpgQ=",
+			"checksumSHA1": "VNhImVFfxO7x8Kp1BrM2zgp4vi0=",
 			"path": "github.com/xanzy/ssh-agent",
-			"revision": "ba9c9e33906f58169366275e3450db66139a31a9",
-			"revisionTime": "2015-12-15T15:34:51Z"
+			"revision": "640f0ab560aeb89d523bb6ac322b1244d5c3796c",
+			"revisionTime": "2018-07-03T18:17:07Z"
 		},
 		{
 			"checksumSHA1": "MlEHIE/60sB86Lmf0MPTIXHzKzE=",


### PR DESCRIPTION
@letzya reported a similar issue (from another project, [here](https://github.com/jfrog/jfrog-cli-go/issues/205)). Seems that updating ssh-agent fixes the compatibility with newer Go versions in Windows builds.