### PR TITLE
Allows local file system to be used as source, fixes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Usage:
 Available Commands:
   dump        Dump will extract policies and APIs from a target (dashboard)
   help        Help about any command
-  publish     publish API definitions from a Git repo to a gateway or dashboard
-  sync        Synchronise a github repo with a gateway
+  publish     publish API definitions from a Git repo or file system to a gateway or dashboard
+  sync        Synchronise a github repo or file system with a gateway
   update      A brief description of your command
 
 Flags:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is it?
 
-Tyk-Git is a command line tool and library to manage and synchronise a Tyk installation with a Git repository.
+Tyk-Git is a command line tool and library to manage and synchronise a Tyk installation with your version control system (VCS).
 
 ## Features
 
@@ -10,10 +10,12 @@ Tyk-Git is a command line tool and library to manage and synchronise a Tyk insta
 - Update APIs on remote Tyk CE Gateways
 - Publish APIS/Policies to remote Tyk Dashboards
 - Publish APIs to remote Tyk CE Gateways
-- Synchronise a Tyk Dashboard's APIs and Policies with those stored in a repository (one-way, Git writes to Dashboard)
-- Synchronise a Tyk CE Gateway's APIs with those stored in a repository (one-way, Git writes to the Gateway)
+- Synchronise a Tyk Dashboard's APIs and Policies with your VCS (one-way, definitions are written to the Dashboard)
+- Synchronise a Tyk CE Gateway's APIs with those stored in a VCS (one-way, definitions are written to the Gateway)
 - Dump Policies and APIs in a transportable format from a Dashboard to a directory
 - Support for importing, converting and publishing Swagger (Open API Spec) files to Tyk.
+- Specialized support for Git. But since API and policy definitions can be read directly from
+the file system, it will integrate with any VCS.
 
 ### Sync
 

--- a/cmd/argchecker.go
+++ b/cmd/argchecker.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func verifyArguments(cmd *cobra.Command) error {
+	gwString, _ := cmd.Flags().GetString("gateway")
+	dbString, _ := cmd.Flags().GetString("dashboard")
+	brString, _ := cmd.Flags().GetString("branch")
+	ptString, _ := cmd.Flags().GetString("path")
+
+	if gwString == "" && dbString == "" {
+		return errors.New(fmt.Sprintf("%s requires either gateway or dashboard target to be set", cmd.Use))
+	}
+
+	if gwString != "" && dbString != "" {
+		return errors.New(fmt.Sprintf("%s requires either gateway or dashboard target to be set, not both", cmd.Use))
+	}
+
+	if ptString != "" && brString != "refs/heads/master" {
+		return errors.New(fmt.Sprintf("%s requires either files or branch to be set, not both", cmd.Use))
+	}
+	return nil
+}
+

--- a/cmd/argchecker.go
+++ b/cmd/argchecker.go
@@ -9,8 +9,6 @@ import (
 func verifyArguments(cmd *cobra.Command) error {
 	gwString, _ := cmd.Flags().GetString("gateway")
 	dbString, _ := cmd.Flags().GetString("dashboard")
-	brString, _ := cmd.Flags().GetString("branch")
-	ptString, _ := cmd.Flags().GetString("path")
 
 	if gwString == "" && dbString == "" {
 		return errors.New(fmt.Sprintf("%s requires either gateway or dashboard target to be set", cmd.Use))
@@ -19,6 +17,9 @@ func verifyArguments(cmd *cobra.Command) error {
 	if gwString != "" && dbString != "" {
 		return errors.New(fmt.Sprintf("%s requires either gateway or dashboard target to be set, not both", cmd.Use))
 	}
+
+	brString, _ := cmd.Flags().GetString("branch")
+	ptString, _ := cmd.Flags().GetString("path")
 
 	if ptString != "" && brString != "refs/heads/master" {
 		return errors.New(fmt.Sprintf("%s requires either files or branch to be set, not both", cmd.Use))

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -13,16 +13,9 @@ var publishCmd = &cobra.Command{
 	Long:  `Publish API definitions from a Git repo to a gateway or dashboard, this
 	will not update existing APIs, and if it detects a collision, will stop.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		gwString, _ := cmd.Flags().GetString("gateway")
-		dbString, _ := cmd.Flags().GetString("dashboard")
-
-		if gwString == "" && dbString == "" {
-			fmt.Println("Publish requires either gateway or dashboard target to be set")
-			return
-		}
-
-		if gwString != "" && dbString != "" {
-			fmt.Println("Publish requires either gateway or dashboard target to be set, not both")
+		verificationError := verifyArguments(cmd)
+		if verificationError != nil {
+			fmt.Println(verificationError)
 			return
 		}
 
@@ -42,5 +35,6 @@ func init() {
 	publishCmd.Flags().StringP("key", "k", "", "Key file location for auth (optional)")
 	publishCmd.Flags().StringP("branch", "b", "refs/heads/master", "Branch to use (defaults to refs/heads/master)")
 	publishCmd.Flags().StringP("secret", "s", "", "Your API secret")
+	publishCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	publishCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
 }

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -9,7 +9,7 @@ import (
 // publishCmd represents the publish command
 var publishCmd = &cobra.Command{
 	Use:   "publish",
-	Short: "publish API definitions from a Git repo to a gateway or dashboard",
+	Short: "publish API definitions from a Git repo or file system to a gateway or dashboard",
 	Long:  `Publish API definitions from a Git repo to a gateway or dashboard, this
 	will not update existing APIs, and if it detects a collision, will stop.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -9,7 +9,7 @@ import (
 // syncCmd represents the sync command
 var syncCmd = &cobra.Command{
 	Use:   "sync",
-	Short: "Synchronise a github repo with a gateway",
+	Short: "Synchronise a github repo or file system with a gateway",
 	Long: `This command will synchronise an API Gateway with the contents of a Github repository, the
 	sync is one way: from the repo to the gateway, the command will not write back to the repo.
 	Sync will delete any objects in the dashboard or gateway that it cannot find in the github repo,

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -15,16 +15,9 @@ var syncCmd = &cobra.Command{
 	Sync will delete any objects in the dashboard or gateway that it cannot find in the github repo,
 	update those that it can find and create those that are missing.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		gwString, _ := cmd.Flags().GetString("gateway")
-		dbString, _ := cmd.Flags().GetString("dashboard")
-
-		if gwString == "" && dbString == "" {
-			fmt.Println("Sync requires either gateway or dashboard target to be set")
-			return
-		}
-
-		if gwString != "" && dbString != "" {
-			fmt.Println("Sync requires either gateway or dashboard target to be set, not both")
+		verificationError := verifyArguments(cmd)
+		if verificationError != nil {
+			fmt.Println(verificationError)
 			return
 		}
 
@@ -44,5 +37,6 @@ func init() {
 	syncCmd.Flags().StringP("branch", "b", "refs/heads/master", "Branch to use (defaults to refs/heads/master)")
 	syncCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	syncCmd.Flags().StringP("org", "o", "", "org ID override")
+	syncCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	syncCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -27,16 +27,9 @@ var updateCmd = &cobra.Command{
 	Long: `Update will attempt to identify matching APIs or Policies in the target, and update those APIs
 	It will not create new ones, to do this use publish or sync.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		gwString, _ := cmd.Flags().GetString("gateway")
-		dbString, _ := cmd.Flags().GetString("dashboard")
-
-		if gwString == "" && dbString == "" {
-			fmt.Println("Update requires either gateway or dashboard target to be set")
-			return
-		}
-
-		if gwString != "" && dbString != "" {
-			fmt.Println("Update requires either gateway or dashboard target to be set, not both")
+		verificationError := verifyArguments(cmd)
+		if verificationError != nil {
+			fmt.Println(verificationError)
 			return
 		}
 
@@ -54,5 +47,6 @@ func init() {
 	updateCmd.Flags().StringP("key", "k", "", "Key file location for auth (optional)")
 	updateCmd.Flags().StringP("branch", "b", "refs/heads/master", "Branch to use (defaults to refs/heads/master)")
 	updateCmd.Flags().StringP("secret", "s", "", "Your API secret")
+	updateCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	updateCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
 }

--- a/tyk-vcs/getter_test.go
+++ b/tyk-vcs/getter_test.go
@@ -1,56 +1,20 @@
 package tyk_vcs
 
 import (
-	"fmt"
-	"github.com/TykTechnologies/tyk/apidef"
 	"testing"
 )
 
-var REPO string = "https://github.com/lonelycode/integration-test.git"
-
-type MockPublisher struct{}
-
-var mockPublish MockPublisher = MockPublisher{}
-
-func (mp MockPublisher) Create(apiDef *apidef.APIDefinition) (string, error) {
-	newID := "654321"
-	fmt.Printf("Creating API ID: %v (on: %v to: %v)\n",
-		newID,
-		apiDef.Proxy.ListenPath,
-		apiDef.Proxy.TargetURL)
-	return newID, nil
-}
-
-func (mp MockPublisher) Update(apiDef *apidef.APIDefinition) error {
-	fmt.Printf("Updating API ID: %v (on: %v to: %v)\n",
-		apiDef.APIID,
-		apiDef.Proxy.ListenPath,
-		apiDef.Proxy.TargetURL)
-
-	return nil
-}
-
-func (mp MockPublisher) Name() string {
-	return "Mock Publisher"
-}
-
-func (mp MockPublisher) Reload() error {
-	return nil
-}
-
-func (mp MockPublisher) Sync(defs []apidef.APIDefinition) error {
-	return nil
-}
+const REPO string = "https://github.com/lonelycode/integration-test.git"
 
 func TestNewGGetter(t *testing.T) {
-	_, e := NewGGetter(REPO, "refs/heads/master", []byte{}, mockPublish)
+	_, e := NewGGetter(REPO, "refs/heads/master", []byte{})
 	if e != nil {
 		t.Fatal(e)
 	}
 }
 
 func TestGitGetter_FetchRepo(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/master", []byte{}, mockPublish)
+	g, e := NewGGetter(REPO, "refs/heads/master", []byte{})
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -62,7 +26,7 @@ func TestGitGetter_FetchRepo(t *testing.T) {
 }
 
 func TestGitGetter_FetchTykSpec(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/master", []byte{}, mockPublish)
+	g, e := NewGGetter(REPO, "refs/heads/master", []byte{})
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -83,7 +47,7 @@ func TestGitGetter_FetchTykSpec(t *testing.T) {
 }
 
 func TestGitGetter_FetchAPIDef(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/master", []byte{}, mockPublish)
+	g, e := NewGGetter(REPO, "refs/heads/master", []byte{})
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -115,7 +79,7 @@ func TestGitGetter_FetchAPIDef(t *testing.T) {
 }
 
 func TestGitGetter_FetchAPIDef_Swagger(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/swagger-test", []byte{}, mockPublish)
+	g, e := NewGGetter(REPO, "refs/heads/swagger-test", []byte{})
 	if e != nil {
 		t.Fatal(e)
 	}


### PR DESCRIPTION
- adds a new command line argument to read definition files from any
  directory on the local file system
- introduces a Getter interface with both  a Git and a file system
  implementation
- centralizes duplicated cli argument verification
- extracts publisher from getter for clearer separation of concerns
